### PR TITLE
Fix backlinks for pages in nested folders

### DIFF
--- a/notes/notes.11tydata.js
+++ b/notes/notes.11tydata.js
@@ -14,7 +14,7 @@ module.exports = {
         title: data => titleCase(data.title || data.page.fileSlug),
         backlinks: (data) => {
             const notes = data.collections.notes;
-            const currentFileSlug = data.page.fileSlug;
+            const currentFileSlug = data.page.filePathStem.replace('/notes/', '');
 
             let backlinks = [];
 


### PR DESCRIPTION
Resolves #41 

Backlinks don't work for pages in nested folders inside of `/notes`. I don't know if there's a better way to get the `/notes/` prefix without hard-coding it like this, but aside from that it's a pretty simple fix.