### PR TITLE
Fix outdated useGitIgnore false

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -33,9 +33,9 @@ module.exports = function(eleventyConfig) {
     });
     
     eleventyConfig.addPassthroughCopy('assets');
+    eleventyConfig.setUseGitIgnore(false);
 
     return {
-        useGitIgnore: false,
         dir: {
             input: "./",
             output: "_site",


### PR DESCRIPTION
Newer versions of 11ty sets this differently. See documentation at: https://www.11ty.dev/docs/ignores/
Tested by adding e.g. notes directory to .gitignore - then 11ty doesn't serve the notes.