### PR TITLE
Normalize backlink slug comparison

### DIFF
--- a/notes/notes.11tydata.js
+++ b/notes/notes.11tydata.js
@@ -4,7 +4,7 @@ const {titleCase} = require("title-case");
 const wikilinkRegExp = /\[\[\s?([^\[\]\|\n\r]+)(\|[^\[\]\|\n\r]+)?\s?\]\]/g
 
 function caselessCompare(a, b) {
-    return a.toLowerCase() === b.toLowerCase();
+    return a.normalize().toLowerCase() === b.normalize().toLowerCase();
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes #87

The issue demonstrated in [jrekier/mind-garden](https://github.com/jrekier/mind-garden) is that while the strings represent the same characters, they are not byte identical. (See "proof" below.) Calling [`String.prototype.normalize()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) before the comparison returns the expected match.

```
$ echo "Poincaré equation" | hexdump -C
00000000  50 6f 69 6e 63 61 72 c3  a9 20 65 71 75 61 74 69  |Poincaré equati|
00000010  6f 6e 0a                                          |on.|
00000013
$ echo "Poincaré equation" | hexdump -C
00000000  50 6f 69 6e 63 61 72 65  cc 81 20 65 71 75 61 74  |Poincare?. equat|
00000010  69 6f 6e 0a                                       |ion.|
00000014
```